### PR TITLE
refactor(ci): add `.github/*` to paths-ignore

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,14 @@ on:
       - main
     paths-ignore:
       - '*.md'
+      - '.github/**/*'
       - '.vscode/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - '*.md'
+      - '.github/**/*'
       - '.vscode/**'
 
 jobs:


### PR DESCRIPTION
## 🔗 Related Issue

- #16 

## 📚 Description

- [x] `.github/*`直下の更新時にESLintワークフローを実行しないように修正しました
