### PR TITLE
fix(ci): fix error for PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,8 @@ jobs:
   # ref: https://github.com/shinGangan/.github/blob/main/.github/workflows/pull_request.yml
   set-pr:
     uses: shinGangan/.github/.github/workflows/pull_request.yml@main
+    # NOTE: Renovate bot が作成した PR には実行しない
+    if: ${{ contains(github.head_ref, 'renovate') == false }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## 🔗 Issue

## 📚 Description

- [x] PR用ワークフローで実行エラーが発生していた。そのため、Renovate Botが作成したPRに対してはワークフローを実行しないように変更。
  - https://github.com/shinGangan/nuxt-nuxtui-templates/actions/runs/13066394997/job/36459402053