### PR TITLE
chore(ci): update pnpm and setup-node actions in CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,8 +28,8 @@ jobs:
         env: [src]
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'


### PR DESCRIPTION
## 🔗 Issue

closed #94 .

## 📚 Description

- [x] ジョブを`corepack enable`から`npm install -g pnpm`に変更しました

## 📝 Reviewer checklist

- [x] Execute `nr dev` command and check http://localhost:3000 .
