### PR TITLE
chore: enable `nuxt/jsdoc` rules

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -13,6 +13,11 @@ export default createConfigForNuxt({
       quotes: 'single',
       commaDangle: 'never',
       braceStyle: '1tbs'
+    },
+    tooling: {
+      jsdoc: true,
+      regexp: true,
+      unicorn: true
     }
   }
 })
@@ -33,6 +38,51 @@ export default createConfigForNuxt({
       ],
       '@typescript-eslint/explicit-function-return-type': 'warn',
       '@typescript-eslint/no-unused-vars': 'warn'
+    }
+  })
+  .override('nuxt/tooling/jsdoc', {
+    rules: {
+      'jsdoc/require-jsdoc': ['warn', {
+        publicOnly: true,
+        require: {
+          ArrowFunctionExpression: true,
+          ClassDeclaration: true,
+          ClassExpression: true,
+          FunctionDeclaration: true,
+          FunctionExpression: true,
+          MethodDefinition: true
+        },
+        contexts: [
+          'VariableDeclaration',
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'TSMethodSignature'
+        ]
+      }],
+      'jsdoc/require-description': ['warn',
+        {
+          contexts: [
+            'ArrowFunctionExpression',
+            'ClassDeclaration',
+            'ClassExpression',
+            'FunctionDeclaration',
+            'FunctionExpression',
+            'MethodDefinition',
+            'PropertyDefinition',
+            'VariableDeclaration',
+            'TSInterfaceDeclaration',
+            'TSTypeAliasDeclaration',
+            'TSPropertySignature',
+            'TSMethodSignature'
+          ]
+        }
+      ],
+      'jsdoc/require-returns': ['off'],
+      'jsdoc/check-tag-names': ['error',
+        {
+          definedTags: ['typeParam', 'remarks']
+        }
+      ]
     }
   })
   .append(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 🔗 Issue

closed #118 .

## 📚 Description

- [x] `nuxt/jsdoc` ruleを有効にしました
  - 設定はこちらの記事を参考に一部チューニングしました
    - ref: https://zenn.dev/wakamsha/articles/setup-eslint-plugin-jsdoc

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のラベルをつけてください
* ![Must](https://img.shields.io/badge/review-Must-orange.svg)
* ![In-my-opinion](https://img.shields.io/badge/review-imo-yellow.svg)
* ![nits](https://img.shields.io/badge/review-Nits-skyblue.svg)
* ![Ask](https://img.shields.io/badge/review-Ask-blue.svg)
-->
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
