### PR TITLE
chore(ci): remove `enhancement 🚀` label in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,11 +10,6 @@
           - 'docs/**/*'
           - '**/*.md'
 
-'enhancement 🚀':
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'src/**/*'
-
 'testing ✅':
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 🔗 Issue

closed #153 .

## 📚 Description

- [x] labeler.ymlの`enhancement 🚀`ラベルを削除
  - PRタイトルからラベル付与するように変更したため不要になった

## 📝 Reviewer checklist

- [ ] Execute `nr dev` command and check http://localhost:3000 .

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
![Must](https://img.shields.io/badge/review-Must-orange.svg)
![In-my-opinion](https://img.shields.io/badge/review-imo-yellow.svg)
![nits](https://img.shields.io/badge/review-Nits-skyblue.svg)
![Ask](https://img.shields.io/badge/review-Ask-blue.svg)
-->
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
